### PR TITLE
Fix: Prevent gvm recursion when sourcing .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -46,7 +46,11 @@ fi
 alias nv='nvim .'
 alias idea="open -na 'IntelliJ IDEA' --args"
 
-[[ -s "/Users/SHINP09/.gvm/scripts/gvm" ]] && source "/Users/SHINP09/.gvm/scripts/gvm"
+# GVM - Go Version Manager
+if [[ -s "/Users/SHINP09/.gvm/scripts/gvm" ]] && [[ -z "$GVM_INIT" ]]; then
+  export GVM_INIT=1
+  source "/Users/SHINP09/.gvm/scripts/gvm"
+fi
 export PATH="/opt/homebrew/opt/mysql-client@8.0/bin:$PATH"
 
 # Set up fzf key bindings and fuzzy completion


### PR DESCRIPTION
## Summary
- gvmの再帰的な初期化を防止し、`.zshrc`を複数回sourceしても安全に動作するように修正

## 問題
- `source ~/.zshrc`を実行すると「job table full or recursion limit exceeded」エラーが発生
- 特にdotfilesディレクトリで`nv`コマンドが使用できない

## 解決策
- `GVM_INIT`フラグを追加して、gvmが既に初期化されているかチェック
- 初回のみgvmスクリプトを読み込むように変更

## テスト
- [x] `source ~/.zshrc`を複数回実行してもエラーが発生しないことを確認
- [x] dotfilesディレクトリで`nv`コマンドが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)